### PR TITLE
chore: move min version to go 1.20

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        golang: [ "1.21", "1.20", "1.19" ]
+        golang: [ "1.22", "1.21", "1.20" ]
         distrib: [ alpine, debian ]
         buildenv: [ base, vendoring ]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go-dvwa
 
-go 1.19
+go 1.20
 
 require (
 	github.com/glebarez/go-sqlite v1.21.2


### PR DESCRIPTION
Smoke tests using go-dvwa are failing when upgrading to WAF v3 in dd-trace-go.
This is because go-libddwaf now uses `errors.Join` introduced in go 1.20, which breaks when running go-dvwa smoke tests on go 1.19.

Smoke test build: https://github.com/DataDog/appsec-go-test-app/actions/runs/8981285035